### PR TITLE
Fixed memory leak in wand rendering

### DIFF
--- a/src/main/java/de/zpenguin/thaumicwands/client/render/item/ItemWandRenderer.java
+++ b/src/main/java/de/zpenguin/thaumicwands/client/render/item/ItemWandRenderer.java
@@ -13,13 +13,13 @@ import net.minecraft.item.ItemStack;
 public class ItemWandRenderer extends TileEntityItemStackRenderer {
 
 	public static TransformType transform = GUI;
+	
+	private final ModelWand modelWand = new ModelWand();
 
 	@Override
 	public void renderByItem(ItemStack stack) {
 		if(stack == null || !(stack.getItem() instanceof ItemWand))
 			return;
-
-		final ModelWand modelWand = new ModelWand();
 
 		GlStateManager.pushMatrix();
 


### PR DESCRIPTION
I found that memory usage kept increasing while a wand was being rendered and tracked the issue down to the item renderer, which created a new wand model every time it was called. Minecraft's model system seems to use display lists to store each model, but it never frees any lists once they are created. This simple fix just makes the model a final field.