### PR TITLE
Fix EntityVisOrbs causing other entities to render as rainbows

### DIFF
--- a/src/main/java/de/zpenguin/thaumicwands/client/render/entity/EntityVisOrbRenderer.java
+++ b/src/main/java/de/zpenguin/thaumicwands/client/render/entity/EntityVisOrbRenderer.java
@@ -62,6 +62,7 @@ public class EntityVisOrbRenderer extends Render<EntityVisOrb> {
 	    tes.draw();
 	    GlStateManager.disableBlend();
 	    GL11.glDisable(32826);
+		GlStateManager.resetColor();
 	    GlStateManager.popMatrix();
 	}
 


### PR DESCRIPTION
The color isn't reset after rendering EntityVisOrbs causing any entites and block entities that render after it to be the same rainbow colors.